### PR TITLE
Fix getting keyStoreAlias for Android builds

### DIFF
--- a/lib/definitions/crypto-identities.d.ts
+++ b/lib/definitions/crypto-identities.d.ts
@@ -37,6 +37,7 @@ interface ICertificateInfo {
 	pemCert: string;
 	organization: string;
 	commonName: string;
+	friendlyName: string;
 	validity: {
 		notBefore: Date;
 		notAfter: Date;

--- a/lib/services/cloud-build-service.js
+++ b/lib/services/cloud-build-service.js
@@ -176,7 +176,7 @@ class CloudBuildService {
             if (this.isReleaseConfiguration(buildConfiguration)) {
                 const certificateS3Data = yield this.uploadFileToS3(projectSettings.projectId, androidBuildData.pathToCertificate);
                 buildProps.Properties.keyStoreName = certificateS3Data.fileNameInS3;
-                buildProps.Properties.keyStoreAlias = yield this.getCertificateCommonName(androidBuildData.pathToCertificate, androidBuildData.certificatePassword);
+                buildProps.Properties.keyStoreAlias = yield this.getCertificateInfo(androidBuildData.pathToCertificate, androidBuildData.certificatePassword).friendlyName;
                 buildProps.Properties.keyStorePassword = androidBuildData.certificatePassword;
                 buildProps.Properties.keyStoreAliasPassword = androidBuildData.certificatePassword;
                 buildProps.BuildFiles.push({
@@ -217,7 +217,7 @@ class CloudBuildService {
                     disposition: "Provision"
                 });
                 buildProps.Properties.CertificatePassword = iOSBuildData.certificatePassword;
-                buildProps.Properties.CodeSigningIdentity = yield this.getCertificateCommonName(iOSBuildData.pathToCertificate, iOSBuildData.certificatePassword);
+                buildProps.Properties.CodeSigningIdentity = yield this.getCertificateInfo(iOSBuildData.pathToCertificate, iOSBuildData.certificatePassword).commonName;
                 const provisionData = this.getMobileProvisionData(iOSBuildData.pathToProvision);
                 const cloudProvisionsData = [{
                         SuffixId: "",
@@ -311,11 +311,6 @@ class CloudBuildService {
             }
         });
     }
-    getCertificateCommonName(certificatePath, certificatePassword) {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this.getCertificateInfo(certificatePath, certificatePassword).commonName;
-        });
-    }
     getCertificateInfo(certificatePath, certificatePassword) {
         const certificateAbsolutePath = path.resolve(certificatePath);
         const certificateContents = this.$fs.readFile(certificateAbsolutePath, { encoding: 'binary' });
@@ -329,7 +324,8 @@ class CloudBuildService {
                         pemCert: forge.pki.certificateToPem(safeBag.cert),
                         organization: issuer && issuer.value,
                         validity: safeBag.cert.validity,
-                        commonName: safeBag.cert.subject.getField(constants.CRYPTO.COMMON_NAME_FIELD_NAME).value
+                        commonName: safeBag.cert.subject.getField(constants.CRYPTO.COMMON_NAME_FIELD_NAME).value,
+                        friendlyName: _.head(safeBag.attributes.friendlyName)
                     };
                 }
             }

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -207,7 +207,7 @@ export class CloudBuildService implements ICloudBuildService {
 			const certificateS3Data = await this.uploadFileToS3(projectSettings.projectId, androidBuildData.pathToCertificate);
 
 			buildProps.Properties.keyStoreName = certificateS3Data.fileNameInS3;
-			buildProps.Properties.keyStoreAlias = await this.getCertificateCommonName(androidBuildData.pathToCertificate, androidBuildData.certificatePassword);
+			buildProps.Properties.keyStoreAlias = await this.getCertificateInfo(androidBuildData.pathToCertificate, androidBuildData.certificatePassword).friendlyName
 			buildProps.Properties.keyStorePassword = androidBuildData.certificatePassword;
 			buildProps.Properties.keyStoreAliasPassword = androidBuildData.certificatePassword;
 
@@ -259,7 +259,7 @@ export class CloudBuildService implements ICloudBuildService {
 			);
 
 			buildProps.Properties.CertificatePassword = iOSBuildData.certificatePassword;
-			buildProps.Properties.CodeSigningIdentity = await this.getCertificateCommonName(iOSBuildData.pathToCertificate, iOSBuildData.certificatePassword);
+			buildProps.Properties.CodeSigningIdentity = await this.getCertificateInfo(iOSBuildData.pathToCertificate, iOSBuildData.certificatePassword).commonName;
 			const provisionData = this.getMobileProvisionData(iOSBuildData.pathToProvision);
 			const cloudProvisionsData: any[] = [{
 				SuffixId: "",
@@ -362,10 +362,6 @@ export class CloudBuildService implements ICloudBuildService {
 		}
 	}
 
-	private async getCertificateCommonName(certificatePath: string, certificatePassword: string): Promise<string> {
-		return this.getCertificateInfo(certificatePath, certificatePassword).commonName;
-	}
-
 	private getCertificateInfo(certificatePath: string, certificatePassword: string): ICertificateInfo {
 		const certificateAbsolutePath = path.resolve(certificatePath);
 		const certificateContents: any = this.$fs.readFile(certificateAbsolutePath, { encoding: 'binary' });
@@ -380,7 +376,8 @@ export class CloudBuildService implements ICloudBuildService {
 						pemCert: forge.pki.certificateToPem(safeBag.cert),
 						organization: issuer && issuer.value,
 						validity: safeBag.cert.validity,
-						commonName: safeBag.cert.subject.getField(constants.CRYPTO.COMMON_NAME_FIELD_NAME).value
+						commonName: safeBag.cert.subject.getField(constants.CRYPTO.COMMON_NAME_FIELD_NAME).value,
+						friendlyName: _.head<string>(safeBag.attributes.friendlyName)
 					};
 				}
 			}


### PR DESCRIPTION
The keyStoreAlias is not the `commonName` that we've been using until now. The correct argument is called `friendlyName`.